### PR TITLE
Fabric 1.20.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.3
-	loader_version=0.14.19
+	minecraft_version=1.20.1
+	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 1.4.3
+	mod_version = 1.4.5
 	maven_group = com.flanks255
 	archives_base_name = simplylight-fabric
 
 # Dependencies
-	fabric_version=0.76.1+1.19.3
+	fabric_version=0.85.0+1.20.1

--- a/src/main/java/com/flanks255/simplylight/SimplyLight.java
+++ b/src/main/java/com/flanks255/simplylight/SimplyLight.java
@@ -3,7 +3,10 @@ package com.flanks255.simplylight;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.CreativeModeTab;
@@ -11,6 +14,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
 
 public class SimplyLight implements ModInitializer {
 	public static final String MODID = "simplylight";
@@ -21,7 +26,16 @@ public class SimplyLight implements ModInitializer {
 
 	public static final TagKey<Item> ANY_STONE = TagKey.create(Registries.ITEM, new ResourceLocation(MODID, "any_stone"));
 
-	public static final CreativeModeTab TAB = FabricItemGroup.builder(new  ResourceLocation(SimplyLight.MODID, "group")).icon(() -> new ItemStack(SLBlocks.ILLUMINANTBLOCK_ON.getItem())).build();
+	public static final CreativeModeTab ITEM_GROUP = FabricItemGroup.builder()
+			.icon(() -> new ItemStack(SLBlocks.ILLUMINANTBLOCK_ON.getItem()))
+			.title(Component.translatable("itemGroup.simplylight.group"))
+			.displayItems((featureFlagSet, output) ->
+					BuiltInRegistries.ITEM.entrySet().stream()
+							.filter(entry -> entry.getKey().location().getNamespace().equals(MODID))
+							.sorted(Comparator.comparing(entry -> BuiltInRegistries.ITEM.getId(entry.getValue())))
+							.forEach(entry -> output.accept(entry.getValue())))
+			.build();
+
 
 	public SimplyLight() {
 		SLBlocks.init();
@@ -32,8 +46,6 @@ public class SimplyLight implements ModInitializer {
 	public void onInitialize() {
 		SLBlocks.register();
 
-		ItemGroupEvents.modifyEntriesEvent(TAB).register(($) ->
-				SLBlocks.TAB_ORDER.forEach(block -> $.accept(block.getItem()))
-				);
+		Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, new ResourceLocation(MODID, "simplylight"), ITEM_GROUP);
 	}
 }

--- a/src/main/java/com/flanks255/simplylight/blocks/EdgeLight.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/EdgeLight.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -27,7 +26,7 @@ public class EdgeLight extends LampBase implements SimpleWaterloggedBlock {
     private final Boolean top;
 
     public EdgeLight(Boolean top) {
-        super(Properties.of(Material.DECORATION)
+        super(Properties.of()
             .strength(1.0f)
             .noCollission()
             .lightLevel((bState) -> 14)

--- a/src/main/java/com/flanks255/simplylight/blocks/LampBlock.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/LampBlock.java
@@ -11,8 +11,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.level.material.MaterialColor;
+import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
 
 import javax.annotation.Nonnull;
@@ -25,17 +24,11 @@ public class LampBlock extends LampBase {
     public final DyeColor color;
 
     public LampBlock(boolean Default, DyeColor colorIn) {
-        super(Properties.of(new Material(
-                MaterialColor.TERRACOTTA_WHITE,
-                false,
-                true,
-                true,
-                true,
-                false,
-                false,
-                PushReaction.NORMAL
-            )).strength(1.0f)
-            .lightLevel((bState)-> bState.getValue(ON) ? 15 : 0));
+        super(Block.Properties.of()
+                .strength(1.0f)
+                .pushReaction(PushReaction.NORMAL)
+                .mapColor(state -> state.getValue(ON) ? MapColor.COLOR_LIGHT_GRAY : MapColor.COLOR_BLACK)
+                .lightLevel((bState)-> bState.getValue(ON) ? 15 : 0));
         this.Default = Default;
         this.color = colorIn;
 

--- a/src/main/java/com/flanks255/simplylight/blocks/LampPost.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/LampPost.java
@@ -35,15 +35,11 @@ public class LampPost extends LampBase implements SimpleWaterloggedBlock {
     private static final VoxelShape BOTTOM_SHAPE = Stream.of(Block.box(3,0,3,13,2,13), Block.box(4,2,4,12,4,12), Block.box(6,4,6,10,16,10)).reduce((a,b) -> Shapes.join(a,b, BooleanOp.OR)).get();
 
     public LampPost() {
-        super(Properties.of(new Material(MaterialColor.COLOR_BLACK,
-            false, //isLiquid
-            true,  //isSolid
-            true, //Blocks Movement
-            false, //isOpaque
-            false, //isFlammable
-            false, //isReplaceable
-            PushReaction.DESTROY
-        )).lightLevel( (bState) -> bState.getValue(POSITION) == Position.TOP?15:0).strength(1.0f));
+        super(Block.Properties.of()
+                .mapColor(MapColor.COLOR_BLACK)
+                .pushReaction(PushReaction.DESTROY)
+                .lightLevel( (bState) -> bState.getValue(POSITION) == Position.TOP?15:0)
+                .strength(1.0f));
 
         registerDefaultState(getStateDefinition().any().setValue(BlockStateProperties.WATERLOGGED, false));
     }

--- a/src/main/java/com/flanks255/simplylight/blocks/LightBulb.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/LightBulb.java
@@ -4,14 +4,13 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Material;
 
 import javax.annotation.Nonnull;
 import java.util.function.BiConsumer;
 
 public class LightBulb extends RotatableLamp {
     public LightBulb() {
-        super(Properties.of(Material.DECORATION)
+        super(Properties.of()
             .noCollission()
             .strength(1.0f)
             .lightLevel((bState) -> 14));

--- a/src/main/java/com/flanks255/simplylight/blocks/RodLamp.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/RodLamp.java
@@ -20,16 +20,7 @@ import java.util.function.BiConsumer;
 @SuppressWarnings("deprecation")
 public class RodLamp extends LampBase implements SimpleWaterloggedBlock {
     public RodLamp () {
-        super(Properties.of(new Material(
-            MaterialColor.TERRACOTTA_WHITE,
-            false, //isLiquid
-            false,  //isSolid
-            true, //Blocks Movement
-            false, //isOpaque
-            false, //isFlammable
-            false, //isReplaceable
-            PushReaction.NORMAL
-        )).strength(1.0f).lightLevel((bState) -> 15));
+        super(Properties.of().strength(1.0f).lightLevel((bState) -> 15));
 
         registerDefaultState(getStateDefinition().any().setValue(BlockStateProperties.WATERLOGGED, false));
     }

--- a/src/main/java/com/flanks255/simplylight/blocks/ThinLamp.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/ThinLamp.java
@@ -6,8 +6,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.material.PushReaction;
 
 import javax.annotation.Nullable;
@@ -18,17 +16,11 @@ public class ThinLamp extends RotatableLamp {
     private final double thickness;
 
     public ThinLamp(double thickness) {
-        super(Properties.of(new Material(
-            MaterialColor.TERRACOTTA_WHITE,
-            false, //isLiquid
-            true,  //isSolid
-            true, //Blocks Movement
-            false, //isOpaque
-            false, //isFlammable
-            false, //isReplaceable
-            PushReaction.NORMAL
-        )).strength(1.0f));
-
+        super(Block.Properties.of()
+                .pushReaction(PushReaction.NORMAL)
+                .lightLevel($ -> 15)
+                .strength(1.0f));
+        
         this.thickness = thickness;
         UP = Block.box(0,0,0, 16, thickness,16);
         DOWN = Block.box(0,16 - thickness,0, 16,16,16);

--- a/src/main/java/com/flanks255/simplylight/blocks/WallLamp.java
+++ b/src/main/java/com/flanks255/simplylight/blocks/WallLamp.java
@@ -3,7 +3,6 @@ package com.flanks255.simplylight.blocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.shapes.Shapes;
 
 import javax.annotation.Nonnull;
@@ -11,8 +10,8 @@ import java.util.function.BiConsumer;
 
 public class WallLamp extends RotatableLamp{
     public WallLamp() {
-        super(Properties.of(Material.DECORATION).noCollission().strength(1.0f).lightLevel((bState) -> 15));
-
+        super(Properties.of().noCollission().strength(1.0f).lightLevel((bState) -> 15));
+        
         UP = Shapes.box(0.375,0.0, 0.375,0.625, 0.125,0.625);
         DOWN = Shapes.box(0.375, 1.0 - 0.125, 0.375, 0.625, 1.0, 0.625);
         EAST = Shapes.box(0.0, 0.375, 0.25, 0.1875, 0.625, 0.75);

--- a/src/main/java/com/flanks255/simplylight/data/SLItemTags.java
+++ b/src/main/java/com/flanks255/simplylight/data/SLItemTags.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class SLItemTags extends ItemTagsProvider {
     public SLItemTags(FabricDataOutput output, CompletableFuture<HolderLookup.Provider> thingIDontUse, FabricTagProvider.BlockTagProvider blockTagsProvider) {
-        super(output, thingIDontUse, blockTagsProvider);
+        super(output, thingIDontUse, blockTagsProvider.contentsGetter());
     }
 
     @Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": "~1.19",
+    "minecraft": "~1.20.1",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
Migrate the 1.19.3/4 Fabric branch to Fabric 0.85+1.20.1

It was mostly removing references to 'Materials' and some changes to the creative mode tab interface.

I'm sure there are some behavioral details that may have gotten lost in removing the 'materials' constructors, but I've not found anything strange so far. 

I was able to build and run on my 1.20.1 Fabric machine - with joy.  :)