### PR TITLE
feat: multiloader publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# simplylight
+# Simply Light
+
 [![Curse Forge](http://cf.way2muchnoise.eu/300331.svg)](https://minecraft.curseforge.com/projects/simply-light)
 [![Curse Forge](http://cf.way2muchnoise.eu/versions/300331.svg)](https://minecraft.curseforge.com/projects/simply-light)
 [![Release](https://github.com/Flanks255/simplylight/actions/workflows/release.yml/badge.svg?branch=master)](https://github.com/Flanks255/simplylight/actions/workflows/release.yml)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,66 @@
 plugins {
     // see https://fabricmc.net/develop/ for new versions
-    id 'fabric-loom' version '1.8-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.13-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.49-beta' apply false
+    id 'net.neoforged.moddev' version '2.0.141' apply false
+    id "me.modmuss50.mod-publish-plugin" version "1.1.0"
+}
+
+apply from: './helpers.gradle'
+
+allprojects {
+    repositories {
+        // Remove past 26.1
+        maven {
+            url = "https://libraries.minecraft.net/"
+            content {
+                includeGroup("org.lwjgl")
+            }
+        }
+    }
+}
+
+def cfToken = providers.environmentVariable("CURSEFORGE_KEY")
+def ghToken = providers.environmentVariable("GITHUB_TOKEN")
+
+publishMods {
+    dryRun = !cfToken.isPresent() || !ghToken.isPresent()
+    type = STABLE
+    version = "${project.version}"
+
+    changelog = createChangelog().trim()
+
+    def createDist = (String modLoader, String jarTask) -> curseforgeOptions {
+        file = project.provider { project(":$modLoader").tasks[jarTask] }.flatMap { it.archiveFile }
+        displayName = "Simply Light ${modLoader.capitalize()} ${project.version}"
+        modLoaders.add(modLoader)
+        accessToken = cfToken
+        projectId = curseforge_id
+        minecraftVersions.add(minecraft_version)
+        javaVersions.add(JavaVersion.VERSION_21)
+    }
+
+    curseforge("curseForgeFabric") {
+        from(createDist("fabric", "remapJar"))
+    }
+
+    curseforge("curseForgeNeoForge") {
+        from(createDist("neoforge", "jar"))
+    }
+
+    curseforge("curseForgeForge") {
+        from(createDist("forge", "jar"))
+    }
+
+    github {
+        file = project.provider { project(":neoforge").tasks.jar }.flatMap { it.archiveFile }
+        additionalFiles.from project.provider { project(":fabric").tasks.remapJar }.flatMap { it.archiveFile }
+        additionalFiles.from project.provider { project(":forge").tasks.jar }.flatMap { it.archiveFile }
+
+        repository = "Flanks255/simplylight"
+        accessToken = ghToken
+
+        commitish = providers.environmentVariable("GITHUB_SHA").orElse("dryRun")
+        tagName = providers.environmentVariable("GITHUB_REF_NAME").orElse("dryRun")
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ publishMods {
         projectId = curseforge_id
         minecraftVersions.add(minecraft_version)
         javaVersions.add(JavaVersion.VERSION_21)
+        if (modLoader == "fabric") {
+            requires("fabric-api")
+        }
     }
 
     curseforge("curseForgeFabric") {

--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -112,8 +112,15 @@ publishing {
         }
     }
     repositories {
-        maven {
-            url System.getenv('local_maven_url')
+        def saps_token = providers.environmentVariable("SAPS_TOKEN")
+        if (saps_token.isPresent()) {
+            maven {
+                url "https://maven.saps.dev/releases"
+                credentials {
+                    username = "flanks"
+                    password = saps_token.get()
+                }
+            }
         }
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -2,9 +2,6 @@ plugins {
     id 'multiloader-loader'
     id 'net.minecraftforge.gradle' version '[6.0.24,6.2)'
 }
-base {
-    archivesName = "${mod_name}-forge-${minecraft_version}"
-}
 
 minecraft {
     mappings channel: 'official', version: minecraft_version
@@ -59,14 +56,6 @@ dependencies {
 
     // Forge's hack fix
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            fg.component(it)
-        }
-    }
 }
 
 sourceSets.each {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/helpers.gradle
+++ b/helpers.gradle
@@ -1,0 +1,30 @@
+// From Mikey
+/**
+ * Seek out the changelog for the current version and return it as a string.
+ */
+ext.createChangelog = () -> {
+    def changelogText = new File("CHANGELOG.md").text
+    def changelog = ""
+
+    def lines = changelogText.split("\n")
+    def inChangelog = false
+    for (int i = 0; i < lines.size(); i++) {
+        def line = lines[i]
+        if (line.startsWith("# ")) {
+            if (inChangelog) {
+                break
+            } else {
+                if (line.contains(project.version)) {
+                    inChangelog = true
+                }
+            }
+        }
+
+        if (inChangelog) {
+            changelog += line + "\n"
+        }
+    }
+
+    def output = changelog.trim()
+    return output.empty ? "No changelog found" : output
+}

--- a/mono/build.gradle
+++ b/mono/build.gradle
@@ -152,37 +152,6 @@ publishing {
     }
 }
 
-// From Mikey
-/**
- * Seek out the changelog for the current version and return it as a string.
- */
-def createChangelog = () -> {
-    def changelogText = new File("CHANGELOG.md").text
-    def changelog = ""
-
-    def lines = changelogText.split("\n")
-    def inChangelog = false
-    for (int i = 0; i < lines.size(); i++) {
-        def line = lines[i]
-        if (line.startsWith("# ")) {
-            if (inChangelog) {
-                break
-            } else {
-                if (line.contains(mod_version)) {
-                    inChangelog = true
-                }
-            }
-        }
-
-        if (inChangelog) {
-            changelog += line + "\n"
-        }
-    }
-
-    def output = changelog.trim()
-    return output.empty ? "No changelog found" : output
-}
-
 def cfToken = providers.environmentVariable("CURSEFORGE_KEY")
 def ghToken = providers.environmentVariable("GITHUB_TOKEN")
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -59,14 +59,18 @@ repositories {
     maven { url = 'https://maven.saps.dev/releases' }
 }
 
+configurations {
+    runtimeClasspath.extendsFrom localRuntime
+}
+
 dependencies {
     compileOnly "mezz.jei:jei-${jei_mc_version}-common-api:${jei_version}"//new
     compileOnly "mezz.jei:jei-${jei_mc_version}-neoforge-api:${jei_version}"
-    runtimeOnly "mezz.jei:jei-${jei_mc_version}-neoforge:${jei_version}"
+    localRuntime "mezz.jei:jei-${jei_mc_version}-neoforge:${jei_version}"
 
 //    compileOnly fg.deobf("curse.maven:TOP-245211:4159743")
-    runtimeOnly "curse.maven:JADE-324717:6853386"
-    runtimeOnly "curse.maven:ATLAS-633577:5490697"
-    runtimeOnly "curse.maven:CTM-267602:5587515"
-    runtimeOnly "curse.maven:BUILDINGGADGETS-298187:5968587"
+    localRuntime "curse.maven:JADE-324717:6853386"
+    localRuntime "curse.maven:ATLAS-633577:5490697"
+    localRuntime "curse.maven:CTM-267602:5587515"
+    localRuntime "curse.maven:BUILDINGGADGETS-298187:5968587"
 }


### PR DESCRIPTION
I've only tested locally but it appears to work.

Things to note:
- If you don't publish to the same CurseForge project, you will need to adjust the project id
- The maven target current [looks like this](https://c.mikey.pro/scr/4/SCR-20260414-qvw.png) if you don't want that, edit the artifactBase inside of the `multiloader-common.gradle` file
- You should be able to yeet `mono` folder now
- Test all jars from the `publishMods` task before running the CI
- Your existing `.github/workflows` should work like normal